### PR TITLE
fix: mempool transactions redundant parse or revert

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -1270,9 +1270,7 @@ Scanner.prototype.parse_new_mempool_transaction = function (raw_transaction_data
     function (l_transaction_data, cb) {
       transaction_data = l_transaction_data
       if (transaction_data) {
-        logger.debug('pre : raw_transaction_data.colored = ', raw_transaction_data.colored)
         _.assign(raw_transaction_data, transaction_data)
-        logger.debug('post: raw_transaction_data.colored = ', raw_transaction_data.colored)
         blockheight = raw_transaction_data.blockheight || -1
         cb(null, blockheight)
       } else {
@@ -1337,8 +1335,8 @@ Scanner.prototype.parse_new_mempool_transaction = function (raw_transaction_data
           iosparsed = raw_transaction_data.iosparsed
           ccparsed = raw_transaction_data.ccparsed
           //to be updated with close_raw_transactions_bulk
-          raw_transaction_data.iosparsed = false 
-          raw_transaction_data.ccparsed = false
+          raw_transaction_data.iosparsed = false  
+          raw_transaction_data.ccparsed = false 
           raw_transaction_bulk.find(conditions).upsert().updateOne(raw_transaction_data)
           if (iosparsed || ccparsed) {
             close_raw_transactions_bulk.find(conditions).updateOne({
@@ -1389,8 +1387,7 @@ Scanner.prototype.parse_mempool_cargo = function (txids, callback) {
   if (ph_index !== -1) {
     txids.splice(ph_index, 1)
   }
-  logger.debug('parsing mempool cargo (' + txids.length + ')')
-  logger.debug('parsing mempool cargo, txid:', txids)
+  logger.debug('parsing mempool cargo (' + txids.length + '). txids =', txids)
 
   txids.forEach(function (txhash) {
     command_arr.push({ method: 'getrawtransaction', params: [txhash, 1]})

--- a/scanner.js
+++ b/scanner.js
@@ -1274,7 +1274,7 @@ Scanner.prototype.parse_new_mempool_transaction = function (raw_transaction_data
         blockheight = raw_transaction_data.blockheight || -1
         cb(null, blockheight)
       } else {
-        // logger.debug('parsing new tx: '+raw_transaction_data.txid)
+        logger.debug('parsing new mempool tx: ' + raw_transaction_data.txid)
         did_work = true
         if (blockheight === -1 && raw_transaction_data.blockhash) {
           get_block_height(raw_transaction_data.blockhash, cb)
@@ -1388,6 +1388,7 @@ Scanner.prototype.parse_mempool_cargo = function (txids, callback) {
     txids.splice(ph_index, 1)
   }
   logger.debug('parsing mempool cargo (' + txids.length + ')')
+  logger.debug('parsing mempool cargo, txid:', txids)
 
   txids.forEach(function (txhash) {
     command_arr.push({ method: 'getrawtransaction', params: [txhash, 1]})

--- a/scanner.js
+++ b/scanner.js
@@ -820,8 +820,9 @@ Scanner.prototype.parse_new_block = function (raw_block_data, callback) {
   var command_arr = []
 
   raw_block_data.tx.forEach(function (txhash) {
-    if (~self.to_revert.indexOf(txhash)) {
-      self.to_revert = []
+    var to_revert_tx_index = self.to_revert.indexOf(txhash)
+    if (to_revert_tx_index !== -1) {
+      self.to_revert.splice(to_revert_tx_index, 1)
     }
     if (self.mempool_txs) {
       var mempool_tx_index = -1
@@ -1537,6 +1538,11 @@ Scanner.prototype.revert_txids = function (callback) {
         execute_bulks_parallel([utxo_bulk, addresses_transactions_bulk, addresses_utxos_bulk, assets_transactions_bulk, assets_utxos_bulk, raw_transaction_bulk], function (err) {
           if (err) return cb(err)
           regular_txids.forEach(function (txid) {
+            var to_revert_tx_index = self.to_revert.indexOf(txid)
+            if (to_revert_tx_index !== -1) {
+              self.to_revert.splice(to_revert_tx_index, 1)
+            }
+            logger.debug('reverted tx ' + txid)
             self.emit('revertedtransaction', {txid: txid})
           })
           colored_txids.forEach(function (txid) {

--- a/scanner.js
+++ b/scanner.js
@@ -1412,7 +1412,7 @@ Scanner.prototype.parse_mempool_cargo = function (txids, callback) {
     raw_transaction_data = to_discrete(raw_transaction_data)
     self.parse_new_mempool_transaction(raw_transaction_data, raw_transaction_bulk, utxo_bulk, addresses_transactions_bulk, addresses_utxos_bulk, assets_transactions_bulk, assets_utxos_bulk, assets_addresses_bulk, close_raw_transactions_bulk, emits, function (err, did_work, iosparsed, ccparsed) {
       if (err) return cb(err)
-      logger.debug('parse_new_mempool_transaction result: txid = ' + raw_transaction_data.txid + ', iosparsed =' + iosparsed + ', ccparsed === colored' + (ccparsed === raw_transaction_data.colored) + ', did_work = ' + did_work)
+      logger.debug('parse_new_mempool_transaction result: txid = ' + raw_transaction_data.txid + ', iosparsed =' + iosparsed + ', ccparsed = ' + ccparsed + ', raw_transaction_data.colored = ' + raw_transaction_data.colored + ', did_work = ' + did_work)
       if (did_work) {
         new_mempool_txs.push({
           txid: raw_transaction_data.txid,

--- a/scanner.js
+++ b/scanner.js
@@ -1412,6 +1412,7 @@ Scanner.prototype.parse_mempool_cargo = function (txids, callback) {
     raw_transaction_data = to_discrete(raw_transaction_data)
     self.parse_new_mempool_transaction(raw_transaction_data, raw_transaction_bulk, utxo_bulk, addresses_transactions_bulk, addresses_utxos_bulk, assets_transactions_bulk, assets_utxos_bulk, assets_addresses_bulk, close_raw_transactions_bulk, emits, function (err, did_work, iosparsed, ccparsed) {
       if (err) return cb(err)
+      logger.debug('parse_new_mempool_transaction result: txid = ' + raw_transaction_data.txid + ', iosparsed =' + iosparsed + ', ccparsed === colored' + (ccparsed === raw_transaction_data.colored) + ', did_work = ' + did_work)
       if (did_work) {
         new_mempool_txs.push({
           txid: raw_transaction_data.txid,

--- a/scanner.js
+++ b/scanner.js
@@ -1270,7 +1270,9 @@ Scanner.prototype.parse_new_mempool_transaction = function (raw_transaction_data
     function (l_transaction_data, cb) {
       transaction_data = l_transaction_data
       if (transaction_data) {
-        raw_transaction_data = transaction_data
+        logger.debug('pre : raw_transaction_data.colored = ', raw_transaction_data.colored)
+        _.assign(raw_transaction_data, transaction_data)
+        logger.debug('post: raw_transaction_data.colored = ', raw_transaction_data.colored)
         blockheight = raw_transaction_data.blockheight || -1
         cb(null, blockheight)
       } else {
@@ -1335,8 +1337,8 @@ Scanner.prototype.parse_new_mempool_transaction = function (raw_transaction_data
           iosparsed = raw_transaction_data.iosparsed
           ccparsed = raw_transaction_data.ccparsed
           //to be updated with close_raw_transactions_bulk
-          raw_transaction_data.iosparsed = false  
-          raw_transaction_data.ccparsed = false 
+          raw_transaction_data.iosparsed = false 
+          raw_transaction_data.ccparsed = false
           raw_transaction_bulk.find(conditions).upsert().updateOne(raw_transaction_data)
           if (iosparsed || ccparsed) {
             close_raw_transactions_bulk.find(conditions).updateOne({


### PR DESCRIPTION
Fixes:
1. Mempool transaction is parsed more than once (and can actually be parsed again and again until it is seen inside block, reverted, or there's a server restart).
2. Mempool transaction is being reverted more than once (and can actually be reverted again and again until it is seen in block or the server restarts).