### PR TITLE
fix: transaction dropped from bitcoind not reverted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
+- 'node'
+- '4.6.1'
 before_script:
 - npm install -g istanbul
 - npm install -g mocha

--- a/scanner.js
+++ b/scanner.js
@@ -1254,8 +1254,8 @@ Scanner.prototype.parse_new_mempool_transaction = function (raw_transaction_data
   var self = this
   var transaction_data
   var did_work = false
-  var iosparsed
-  var ccparsed
+  var iosparsed = false
+  var ccparsed = false
   var blockheight = -1
   // var parsing_vin = false
   var emits = []

--- a/scanner.js
+++ b/scanner.js
@@ -1448,7 +1448,7 @@ Scanner.prototype.parse_mempool_cargo = function (txids, callback) {
               self.mempool_txs.push(tmp_mempool_tx)
             }
           })
-          if (debug) console.time('add or assign mempool transactions to cache')
+          if (debug) console.timeEnd('add or assign mempool transactions to cache')
         }
         emits.forEach(function (emit) {
           self.emit(emit[0], emit[1])

--- a/scanner.js
+++ b/scanner.js
@@ -1272,6 +1272,10 @@ Scanner.prototype.parse_new_mempool_transaction = function (raw_transaction_data
       if (transaction_data) {
         _.assign(raw_transaction_data, transaction_data)
         blockheight = raw_transaction_data.blockheight || -1
+        if (self.mempool_txs && self.mempool_txs.indexOf(transaction_data.txid) !== -1 && blockheight === -1) {
+          // if found as unconfirmed transaction in DB - push to cache (possibly pushed to DB by different process)
+          self.mempool_txs.push(transaction_data.txid)
+        }
         cb(null, blockheight)
       } else {
         logger.debug('parsing new mempool tx: ' + raw_transaction_data.txid)


### PR DESCRIPTION
**What happened?**
a. Transaction T is being parsed by process A (for example process `API` when calling `POST /api/transmit`).
   Process A inserts transaction T to DB and its *local* cache (`self.mempool_txs`).
b. Transaction T is picked up by process B (for example process `SCANNER`) as part of its periodic `parse_new_mempool` execution - because it's in DB but not in in process B's local mempool cache.
c. process B, when coming to parse transaction T as part of `parse_mempool_cargo` - does not perform any parsing work since it is already fully parsed by process A.
As a result, process B does not insert transaction T into its local cache, and so it continuously picking up the same transaction T until it is wiped from bitcoind's mempool.
d. bitcoind wipes transaction T from its mempool, becuase a *double spend* transaction T' of it has appeared in a new block.
e. process B still does not have transaction T in its local mempool cache, which causes the transaction not to be reverted.
f. One sees transaction T and its double spend T' live together in the DB.

**What should have happened?**
Wiping transaction T from bitcoin should have caused it to be wiped from explorer's DB as well.

**How this is solved?**
During `parse_mempool_cargo`: a transaction is added to `tmp_mempool_txs`, which is the array of candidate mempool transactions to add to cache - _even if no work has done on it in the context of the current process_.
Then, if it isn't already in mempool cache - it is added to it. 
Otherwise, the candidate unconfirmed transaction's values are being assigned to its corresponding object in the cache.

**Note 1:**
This fix tries to overcome the issue where different processes have different cache, which is local - the memory held by this process.
Using a common  cache layer, such as a single process Redis DB - can solve this issue as well.
**Note 2:**
Adding *every* mempool transaction picked up by `parse_mempool_cargo` as a candidate to be added to cache has some overhead - eventually it will need to iterate m * n - where m is the cargo concurrency, and n is the size of the mempool cache.
However, that is way faster than choosing to force the priority parse process to be done on the same process and paying the price of a context switch.